### PR TITLE
Groups GitHub Actions and Docker Images for Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directories:
       - "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
Make dependencybot updates more efficient by separately grouping all GitHub action and Docker image updates into single PRs.