### PR TITLE
Adds VS Code files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"golang.go",
+		"SonarSource.sonarlint-vscode"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Go Test",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${fileDirname}",
+            "env": {
+                "PATH": "${env:PATH}:${workspaceFolder}/bin"
+            },
+            "presentation": {
+                "hidden": false,
+                "group": "test",
+                "order": 1,
+
+            },
+            "preLaunchTask": "go: build inspections",
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "go.testEnvVars": {
+        "PATH": "${env:PATH}:${workspaceFolder}/bin"
+    },
+    "go.testFlags": [
+        "--ginkgo.github-output"
+    ],
+    "sonarlint.connectedMode.project": {
+        "connectionId": "raft-tech",
+        "projectKey": "raft-tech_konfirm-inspect"
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,80 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "go: test",
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			},
+			"type": "go",
+			"command": "test",
+			"args": ["./cmd/...", "./internal/...", "./pkg/..."],
+			"options": {
+				"env": {
+					"PATH": "${env:PATH}:${workspaceFolder}/bin"
+				}
+			},
+			"problemMatcher": [
+				"$go"
+			]
+		},
+		{
+			"label": "go: build inspections",
+			"detail": "Buils all Konfirm inspections required for testing",
+			"dependsOn": [
+				"go: build konfirm-http",
+				"go: build konfirm-storage"
+			],
+			"problemMatcher": [
+				"$go"
+			]
+		},
+		{
+			"label": "go: build konfirm-http",
+			"detail": "Builds konfirm-http, which is required for testing",
+			"group": "build",
+			"hide": true,
+			"type": "go",
+			"command": "test",
+			"args": [
+				"-tags",
+				"inspection",
+				"-c",
+				"-o",
+				"bin/konfirm-http",
+				"./inspections/http"
+			],
+			"problemMatcher": [
+				"$go"
+			],
+			"presentation": {
+				"reveal": "silent",
+				"revealProblems": "onProblem",
+			}
+		},
+		{
+			"label": "go: build konfirm-storage",
+			"detail": "Builds konfirm-storage, which is required for testing",
+			"group": "build",
+			"hide": true,
+			"type": "go",
+			"command": "test",
+			"args": [
+				"-tags",
+				"inspection",
+				"-c",
+				"-o",
+				"bin/konfirm-storage",
+				"./inspections/storage"
+			],
+			"problemMatcher": [
+				"$go"
+			],
+			"presentation": {
+				"reveal": "silent",
+				"revealProblems": "onProblem",
+			}
+		}
+	]
+}

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ inspect:
 
 .PHONY: bin/konfirm-http
 bin/konfirm-http:
-	go test -c -o bin/konfirm-http ./inspections/http
+	go test -tags inspection -c -o bin/konfirm-http ./inspections/http
 
 .PHONY: bin/konfirm-storage
 bin/konfirm-storage:
-	go test -c -o bin/konfirm-storage ./inspections/storage
+	go test -tags inspection -c -o bin/konfirm-storage ./inspections/storage

--- a/inspections/http/inspection_test.go
+++ b/inspections/http/inspection_test.go
@@ -1,3 +1,5 @@
+//go:build inspection
+
 /*
  * Copyright (c) 2024 Raft, LLC
  *

--- a/inspections/storage/inspection_test.go
+++ b/inspections/storage/inspection_test.go
@@ -1,3 +1,6 @@
+//go:build inspection
+// +build inspection
+
 /*
  * Copyright (c) 2024 Raft, LLC
  *

--- a/inspections/storage/obeserver.go
+++ b/inspections/storage/obeserver.go
@@ -1,3 +1,5 @@
+//go:build inspection
+
 /*
  * Copyright (c) 2024 Raft, LLC
  *


### PR DESCRIPTION
Adds `.vscode` dir and uses Go [build tags](https://pkg.go.dev/go/build#hdr-Build_Constraints) to isolate inspection tests.